### PR TITLE
List poznańskich ulic, skwerów, placów, rond i parków z bazy TERYT

### DIFF
--- a/db/teryt.csv
+++ b/db/teryt.csv
@@ -1,0 +1,2717 @@
+Aleja 15 Pułku Ułanów Poznańskich
+Ulica 23 Lutego
+Ulica 27 Grudnia
+Ulica 28 Czerwca 1956 r.
+Ulica 3 Maja
+Ulica 3. Pułku Lotniczego
+Skwer 4 Czerwca 1989 r.
+Ulica 5 Stycznia
+Ulica Abpa Antoniego Baraniaka
+Skwer Abpa Edwarda Likowskiego
+Ulica Abpa Walentego Dymka
+Plac Adama Asnyka
+Ulica Adama Asnyka
+Ulica Adama Białoszyńskiego
+Ulica Adama Biedrzyckiego
+Ulica Adama Grześkiewicza
+Ulica Adama Haber-Włyńskiego
+Ulica Adama Kręglewskiego
+Ulica Adama Logi
+Park Adama Mickiewicza
+Plac Adama Mickiewicza
+Ulica Adama Mickiewicza
+Ulica Adama Poszwińskiego
+Ulica Adama Skałkowskiego
+Ulica Adama Tomaszewskiego
+Park Adama Wodziczki
+Ulica Adama Wrzoska
+Ulica Adm. Józefa Unruga
+Ulica Admiralska
+Ulica Adolfa Bnińskiego
+Skwer Ady Rusowicz
+Ulica Agatowa
+Skwer Agnieszki Osieckiej
+Ulica Agrestowa
+Ulica Ajschylosa
+Ulica Akacjowa
+Ulica Albańska
+Park Alberta Camusa
+Aleja Aleje Karola Marcinkowskiego
+Aleja Aleje Solidarności
+Ulica Aleksandra Fredry
+Ulica Aleksandra Gabszewicza
+Ulica Aleksandra Hercena
+Ulica Aleksandra Puszkina
+Ulica Aleksandra Studniarskiego
+Ulica Aleksandry Bielerzewskiej
+Ulica Aleksandry Karpińskiej
+Ulica Alicji Iwańskiej
+Rondo Alicji Karłowskiej-Kamzowej
+Skwer Alojzego Andrzeja Łuczaka
+Ulica Alojzego Nowaka
+Ulica Altanowa
+Ulica Alzacka
+Ulica Amelii Łączyńskiej
+Ulica Ametystowa
+Ulica Ananasowa
+Ulica Andaluzyjska
+Ulica Andrychowska
+Ulica Andrzeja I Władysława Niegolewskich
+Ulica Andrzeja Kopy
+Ulica Andrzeja Łaskarza
+Skwer Andrzeja Rzewuskiego
+Ulica Andrzeja Sobczaka
+Skwer Anieli Chosłowskiej
+Ulica Anieli Pigoń
+Ulica Anieli Tułodzieckiej
+Ulica Anny Danysz
+Ulica Anny German
+Ulica Anny Jantar
+Ulica Anny Leskiej-Daab
+Ulica Anny Memoraty
+Ulica Antona Czechowa
+Ulica Antoniego Andrzejewskiego
+Skwer Antoniego Babińskiego
+Ulica Antoniego Gołubiewa
+Ulica Antoniego Kocjana
+Ulica Antoniego Kosińskiego
+Ulica Antoniego Kotowicza
+Ulica Antoniego Madalińskiego
+Ulica Antoniego Małeckiego
+Skwer Antoniego Pallutha
+Skwer Antoniego Peretiatkowicza
+Rondo Antoniego Wojewody
+Skwer Antoniny Kaweckiej
+Ulica Anyżowa
+Ulica Aragońska
+Ulica Architektów
+Ulica Arkadego Fiedlera
+Ulica Arkońska
+Ulica Armeńska
+Osiedle Armii Krajowej
+Aleja Armii Poznań
+Ulica Arnikowa
+Ulica Arnolda Szylinga
+Ulica Aroniowa
+Ulica Artura Grottgera
+Ulica Artura Marii Swinarskiego
+Ulica Artura Oppmana
+Ulica Arystofanesa
+Park Astronomiczny Jana Heweliusza
+Ulica Astrowa
+Ulica Augusta Cieszkowskiego
+Ulica Augusta Emila Fieldorfa
+Ulica Augustowska
+Ulica Augustyna Kordeckiego
+Ulica Augustyna Szamarzewskiego
+Ulica Azaliowa
+Ulica Babicka
+Ulica Babiego Lata
+Ulica Babimojska
+Osiedle Bajkowe
+Ulica Bakaliowa
+Ulica Balonowa
+Ulica Baltazara Lewandowskiego
+Ulica Bałtycka
+Park Bambrów Poznańskich
+Ulica Bananowa
+Ulica Barana
+Ulica Baranowska
+Ulica Barbary Lerczakówny
+Ulica Barcińska
+Ulica Barczewska
+Ulica Barlinecka
+Ulica Barska
+Ulica Bartnicza
+Ulica Bartoszycka
+Ulica Barwicka
+Ulica Bastionowa
+Ulica Baśniowa
+Ulica Batalionów Chłopskich
+Ulica Bazyliowa
+Ulica Bażancia
+Ulica Bednarska
+Ulica Begoniowa
+Ulica Belwederska
+Ulica Bełchatowska
+Ulica Benedykta Dybowskiego
+Ulica Benedykta Tadeusza Dybowskiego
+Ulica Berberysowa
+Ulica Berdychowo
+Ulica Berestecka
+Plac Bernardyński
+Ulica Berylowa
+Ulica Beskidzka
+Ulica Beztroska
+Ulica Będlewska
+Ulica Będzińska
+Ulica Biała
+Ulica Białczańska
+Ulica Białoborska
+Ulica Białobrzeska
+Ulica Białogardzka
+Ulica Białoruska
+Ulica Białostocka
+Ulica Białośliwska
+Ulica Bibianny Moraczewskiej
+Ulica Biebrzańska
+Ulica Biecka
+Ulica Bielicowa
+Ulica Bielniki
+Ulica Bielska
+Ulica Biesiadna
+Ulica Bieszczady
+Ulica Biskupińska
+Skwer Bitwy nad Bzurą
+Ulica Bitwy pod Siekierkami
+Ulica Bitwy pod Studziankami
+Ulica Biwakowa
+Ulica Blacharska
+Ulica Bliźniąt
+Ulica Bluszczowa
+Ulica Bł. Marii Karłowskiej
+Ulica Bł. Marii Sancji Szymkowiak
+Ulica Bł. Marka z Aviano
+Rondo Bł. Natalii Tułasiewicz
+Ulica Bławatkowa
+Ulica Błażeja
+Ulica Błażeja Winklera
+Ulica Błękitna
+Ulica Błogosławionej Poznańskiej Piątki
+Ulica Błońska
+Ulica Błotna
+Ulica Bnińska
+Ulica Bobolicka
+Ulica Bobrownicka
+Ulica Bobrzańska
+Ulica Bocheńska
+Ulica Bociania
+Ulica Boczna
+Ulica Boczowska
+Ulica Bodawska
+Skwer Bogdana Jańskiego
+Ulica Bogdanowska
+Ulica Bogumiła
+Ulica Bogumiła Krygowskiego
+Ulica Bogusława
+Ulica Bogusza
+Skwer Bohaterów Akcji Bollwerk
+Osiedle Bohaterów II Wojny Światowej
+Ulica Bohaterów Westerplatte
+Ulica Bohdana Arcta
+Skwer Bohdana Smolenia
+Ulica Bohdana Winiarskiego
+Ulica Bojanowska
+Ulica Bojerowa
+Osiedle Bolesława Chrobrego
+Ulica Bolesława Czerwińskiego
+Ulica Bolesława Kontryma
+Ulica Bolesława Krysiewicza
+Ulica Bolesława Krzywoustego
+Ulica Bolesława Leśmiana
+Ulica Bolesława Limanowskiego
+Ulica Bolesława Prusa
+Osiedle Bolesława Śmiałego
+Ulica Bolesławy
+Ulica Bolka
+Ulica Bolkowicka
+Ulica Bonin
+Ulica Boranta
+Ulica Borecka
+Ulica Borowa
+Ulica Borowikowa
+Ulica Borówki
+Ulica Borówkowa
+Ulica Borsucza
+Ulica Boruty
+Ulica Bosa
+Ulica Bosmańska
+Ulica Botaniczna
+Ulica Bożeny
+Ulica Bożydara
+Ulica Bożymira
+Ulica Bożywoja
+Ulica Bóżnicza
+Ulica Braniborska
+Ulica Braniewska
+Ulica Bratkowa
+Ulica Bratumiły
+Ulica Brneńska
+Ulica Brodnicka
+Ulica Brokułowa
+Ulica Bronisława
+Skwer Bronisława Geremka
+Ulica Bronisława Malinowskiego
+Ulica Bronisza
+Ulica Bronowa
+Ulica Browarna
+Ulica Bruzdowa
+Ulica Brylantowa
+Ulica Brzask
+Ulica Brzeska
+Ulica Brzeźnicka
+Ulica Brzoskwiniowa
+Ulica Brzozowa
+Ulica Budzisława
+Ulica Budziszyńska
+Ulica Budzyńska
+Ulica Bukowa
+Ulica Bukowska
+Ulica Bułgarska
+Ulica Burgundzka
+Ulica Bursztynowa
+Ulica Burtowa
+Ulica Burysława
+Ulica Burzowa
+Ulica Buska
+Ulica Bużańska
+Ulica Bychawska
+Ulica Byczyńska
+Ulica Bydgoska
+Ulica Byka
+Ulica Bylicowa
+Ulica Bystra
+Ulica Bystrzycka
+Ulica Bytomska
+Ulica Bzowa
+Ulica Cedrowa
+Ulica Cedzyńska
+Ulica Ceglana
+Ulica Celichowskich
+Ulica Ceramiczna
+Ulica Cerekwicka
+Ulica Cetniewska
+Ulica Chabrowa
+Ulica Chartowo
+Ulica Charzykowska
+Ulica Chełmińska
+Ulica Chemiczna
+Ulica Chęcińska
+Ulica Chlebowa
+Ulica Chłodna
+Ulica Chmielna
+Ulica Chmurna
+Ulica Chochołowska
+Ulica Chociebora
+Ulica Chocimska
+Ulica Chodzieska
+Ulica Chojnicka
+Ulica Chomęcicka
+Ulica Choszczeńska
+Ulica Chotomińska
+Ulica Christiana Andersena
+Ulica Chrobacka
+Ulica Chryzantemowa
+Ulica Chrzanowska
+Ulica Chwaliszewo
+Ulica Chyżańska
+Ulica Ciasna
+Ulica Cicha
+Rondo Cichowiczów
+Ulica Ciechocińska
+Ulica Cienista
+Ulica Cieplicka
+Ulica Cieszymira
+Ulica Cieszyńska
+Ulica Cisowa
+Ulica Cmentarna
+Ulica Conrada Drzewieckiego
+Ulica Cumownicza
+Ulica Cybińska
+Ulica Cynamonowa
+Ulica Cyniowa
+Ulica Cypriana Norwida
+Ulica Cyprysowa
+Ulica Cyraneczki
+Ulica Cyrkoniowa
+Plac Cyryla Ratajskiego
+Park Cytadela
+Aleja Cytadelowców
+Ulica Cytrynowa
+Ulica Czajcza
+Ulica Czapla
+Ulica Czaplinecka
+Ulica Czarna Rola
+Ulica Czarnkowska
+Ulica Czarnohorska
+Ulica Czarnucha
+Ulica Czartoria
+Osiedle Czecha
+Ulica Czechosłowacka
+Ulica Czechowska
+Ulica Czekalskie
+Ulica Czekoladowa
+Ulica Czeladzka
+Ulica Czempińska
+Ulica Czeremchowa
+Ulica Czereśniowa
+Ulica Czernichowska
+Ulica Czerniejewska
+Ulica Czerska
+Ulica Czerwonacka
+Ulica Czesława Gerwela
+Skwer Czesława Janickiego
+Ulica Czesława Miłosza
+Ulica Czesława Niemena
+Ulica Czesława Tańskiego
+Ulica Cześnikowska
+Ulica Częstochowska
+Ulica Człopska
+Ulica Człuchowska
+Ulica Czorsztyńska
+Ulica Czwartaków
+Ulica Czysta
+Ulica Ćmielowska
+Ulica Daktylowa
+Ulica Daleka
+Ulica Dalemińska
+Ulica Daliowa
+Skwer Damazego Trzcińskiego
+Ulica Danuty
+Ulica Darłowska
+Ulica Darniowa
+Ulica Darzyborska
+Ulica Darzyńska
+Ulica Daszewicka
+Ulica Dąbrówki
+Ulica Dedala
+Ulica Dereniowa
+Ulica Deszczowa
+Ulica Dezyderego Chłapowskiego
+Ulica Dębicka
+Osiedle Dębina
+Ulica Dęblińska
+Ulica Dębowa
+Ulica Diamentowa
+Ulica Długa
+Ulica Dniestrzańska
+Ulica Do Alei
+Ulica Dobiegniewska
+Ulica Dobra
+Ulica Dobrego Pasterza
+Ulica Dobrepole
+Ulica Dobrochny
+Ulica Dobrodzieńska
+Ulica Dobromiejska
+Ulica Dobromiły
+Ulica Dobrowita
+Ulica Dojazd
+Ulica Doleńska
+Ulica Dolina
+Ulica Dolna
+Ulica Dolna Wilda
+Ulica Dolne Chyby
+Ulica Dolska
+Ulica Dominikańska
+Ulica Dożynkowa
+Ulica Drawska
+Ulica Drewlańska
+Ulica Drobna
+Ulica Droga Dębińska
+Ulica Drogocin
+Ulica Drogowców
+Ulica Druskienicka
+Ulica Drużynowa
+Ulica Drwali
+Ulica Dukielska
+Ulica Dunajecka
+Ulica Dusznicka
+Ulica Dwatory
+Ulica Dworcowa
+Ulica Dworkowa
+Ulica Dworska
+Ulica Dyniowa
+Ulica Dynowska
+Ulica Dziadoszańska
+Ulica Działkowa
+Ulica Działoszycka
+Ulica Działowa
+Ulica Działyńskich
+Ulica Dzicza
+Ulica Dzieci Wrzesińskich
+Ulica Dziedzicka
+Ulica Dziekańska
+Ulica Dziewanny
+Ulica Dziewińska
+Ulica Dzięgielowa
+Ulica Dzikiej Róży
+Ulica Dziurawcowa
+Ulica Dziwnowska
+Ulica Edmunda Calliera
+Ulica Edmunda Knolla-Kownackiego
+Ulica Edmunda Taczanowskiego
+Ulica Edwarda Dembowskiego
+Skwer Edwarda Fiszera
+Ulica Edwarda Raczyńskiego
+Aleja Edwarda Stachury
+Ulica Edwarda Taylora
+Skwer Eki z Małeki
+Ulica Elbląska
+Ulica Elizy Orzeszkowej
+Ulica Elżbiety Drużbackiej
+Ulica Elżbiety Zawackiej
+Ulica Emila Zoli
+Ulica Emilii Plater
+Ulica Emilii Sczanieckiej
+Ulica Emilii Waśniowskiej
+Ulica Emmy Puffke
+Ulica Energetyczna
+Ulica Epicka
+Ulica Estońska
+Ulica Eugeniusza Kwiatkowskiego
+Ulica Eugeniusza Paukszty
+Ulica Eugeniusza Piaseckiego
+Ulica Eurypidesa
+Ulica Ewangelicka
+Ulica Ewarysta Estkowskiego
+Ulica Ewy Szelburg-Zarembiny
+Ulica Ezopa
+Ulica Fabianowo
+Ulica Fabryczna
+Ulica Falista
+Ulica Faszynowa
+Ulica Fedrusa
+Park Felicjana Sypniewskiego
+Ulica Feliksa Nowowiejskiego
+Ulica Feliksa Tychowskiego
+Skwer Ferdynanda Focha
+Ulica Figowa
+Ulica Filarecka
+Skwer Filipiny I Konstancji Studzińskich
+Ulica Filipińska
+Ulica Fiołkowa
+Ulica Floksowa
+Ulica Florentyny Luboińskiej
+Ulica Floriana Marciniaka
+Ulica Floriana Stablewskiego
+Ulica Floriana Znanieckiego
+Ulica Folwarczna
+Ulica Forsycjowa
+Ulica Forteczna
+Park Forteczny
+Ulica Franciszka Adamanisa
+Ulica Franciszka Altera
+Ulica Franciszka Firlika
+Ulica Franciszka Hynka
+Ulica Franciszka Jacha
+Ulica Franciszka Jaśkowiaka
+Ulica Franciszka Kleeberga
+Ulica Franciszka Lubeckiego
+Ulica Franciszka Morawskiego
+Skwer Franciszka Rataja
+Ulica Franciszka Ratajczaka
+Ulica Franciszka Rylla
+Ulica Franciszka Stróżyńskiego
+Ulica Franciszka Witaszka
+Ulica Franciszka Włada
+Ulica Franciszka Żwirki
+Ulica Franciszkańska
+Ulica Franklina Roosevelta
+Ulica Franowo
+Ulica Fregatowa
+Ulica Frezjowa
+Ulica Fromborska
+Park Fryderyka Chopina
+Ulica Fryderyka Chopina
+Ulica Fryderyka Schillera
+Ulica Fryderyka Skarbka
+Skwer Fyrtel przy Ogniku
+Ulica Gabrieli Zapolskiej
+Ulica Gajowa
+Ulica Galeonowa
+Ulica Galileusza
+Ulica Galla Anonima
+Ulica Garaszewo
+Ulica Garbary
+Ulica Gardowska
+Ulica Garncarska
+Ulica Gąsawska
+Ulica Gąsiorowskich
+Ulica Gdańska
+Ulica Gdyńska
+Ulica Gen. Stanisława Maczka
+Aleja Gen. Stanisława Sosabowskiego
+Ulica Gen. Tadeusza Kutrzeby
+Park Generała Henryka Dąbrowskiego
+Ulica Geodetów
+Ulica George'A Byrona
+Skwer Gerarda Labudy
+Ulica Gerberowa
+Ulica Gertrudy Konatkowskiej
+Ulica Gęsia
+Ulica Gieorgija Dobrowolskiego
+Ulica Giżycka
+Ulica Gladiolowa
+Ulica Glebowa
+Ulica Glinianki
+Ulica Glinienko
+Ulica Glinno
+Ulica Gliwicka
+Ulica Gładka
+Ulica Głazowa
+Ulica Głęboka
+Ulica Głogowa
+Ulica Głogowska
+Ulica Głowicka
+Ulica Główna
+Ulica Głuchowska
+Ulica Głuszyna
+Ulica Gminna
+Ulica Gniewka
+Ulica Gniewska
+Ulica Gnieźnieńska
+Ulica Goleszowska
+Ulica Golęcińska
+Ulica Golęczewska
+Ulica Gołdapska
+Ulica Gołębia
+Ulica Gołężycka
+Ulica Gołuchowska
+Ulica Goplańska
+Ulica Gorajska
+Ulica Gorczycowa
+Ulica Gorlicka
+Ulica Gorzowska
+Ulica Gorzyńska
+Ulica Gorzysława
+Ulica Gospodarska
+Ulica Gostyńska
+Ulica Gościnna
+Ulica Gothilfa Bergera
+Ulica Goździkowa
+Ulica Góra Przemysła
+Ulica Góralska
+Ulica Górczyńska
+Park Górczyński
+Ulica Górecka
+Ulica Górki
+Ulica Górna Wilda
+Ulica Górnicza
+Ulica Górska
+Ulica Grabowa
+Ulica Grabowska
+Ulica Gradowa
+Ulica Grajewska
+Ulica Granatowa
+Ulica Graniczna
+Ulica Graniowa
+Ulica Granowska
+Ulica Grąbczowska
+Ulica Grobla
+Ulica Grochowe Łąki
+Ulica Grochowska
+Ulica Grodnicka
+Ulica Grodzieńska
+Ulica Grodziska
+Ulica Gromadzka
+Ulica Gronostajowa
+Ulica Gronowa
+Ulica Groszkowa
+Ulica Grotkowska
+Ulica Grójecka
+Ulica Grudziądzka
+Ulica Grudzieniec
+Ulica Gruntowa
+Ulica Grunwaldzka
+Ulica Gruszkowa
+Ulica Gruzińska
+Ulica Gryczana
+Ulica Gryfińska
+Ulica Grzegorza Ciechowskiego
+Ulica Grzybowa
+Ulica Gubińska
+Ulica Guliwera
+Ulica Gustawa Herlinga-Grudzińskiego
+Ulica Gustawa Macewicza
+Park Gustawa Manitiusa
+Ulica Gustawa Potworowskiego
+Ulica Gwarna
+Ulica Gwiaździsta
+Ulica Hajduczka
+Ulica Haliny
+Ulica Haliny Brodowskiej
+Ulica Haliny Konopackiej
+Ulica Haliny Poświatowskiej
+Skwer Haliny Szwarc
+Ulica Halna
+Ulica Halszki
+Ulica Halszki Osmólskiej
+Ulica Hangarowa
+Ulica Hanny Januszewskiej
+Ulica Hanny Malewskiej
+Ulica Harcerska
+Ulica Hawelańska
+Ulica Heleny Kurcewiczówny
+Ulica Heleny Modrzejewskiej
+Ulica Heleny Rzepeckiej
+Ulica Heleny Szafran
+Ulica Heleny Tadeuszak
+Ulica Heliodora Święcickiego
+Ulica Helska
+Ulica Henryka Arctowskiego
+Skwer Henryka Derwicha
+Ulica Henryka Jordana
+Ulica Henryka Kowalówki
+Ulica Henryka Łowmiańskiego
+Ulica Henryka Opieńskiego
+Ulica Henryka Siemiradzkiego
+Ulica Henryka Sienkiewicza
+Ulica Henryka Sucharskiego
+Ulica Henryka Śniegockiego
+Ulica Henryka Ułaszyna
+Ulica Henryka Wieniawskiego
+Park Henryka Wieniawskiego
+Ulica Henryka Zygalskiego
+Ulica Herbowa
+Ulica Hetmańska
+Osiedle Hetmańskie HCP
+Ulica Heweliusza
+Ulica Hezjoda
+Ulica Hiacyntowa
+Ulica Hipolita Cegielskiego
+Ulica Hodowlana
+Ulica Homera
+Ulica Honoriusza Balzaka
+Rondo Honorowych Dawców Krwi
+Ulica Horacego
+Ulica Hoża
+Ulica Hrubieszowska
+Ulica Hubalczyków
+Ulica Huby Moraskie
+Ulica Hugona Kołłątaja
+Ulica Hulewiczów
+Ulica Husarska
+Ulica Hutnicza
+Ulica Idy Fink
+Ulica Iglasta
+Ulica Ignacego Daszyńskiego
+Ulica Ignacego Dobrogojskiego
+Ulica Ignacego Domeyki
+Ulica Ignacego Kaczmarka
+Ulica Ignacego Krasickiego
+Skwer Ignacego Łukasiewicza
+Ulica Ignacego Paderewskiego
+Ulica Ignacego Prądzyńskiego
+Ulica Ignacego Zielewicza
+Ulica Ikara
+Ulica Iłowska
+Ulica Iłżańska
+Park Im. Karola Kurpińskiego
+Ulica Imbirowa
+Ulica Inflancka
+Ulica Inowrocławska
+Ulica Inspektowa
+Ulica Ireneusza Wierzejewskiego
+Skwer Ireny Bobowskiej
+Skwer Ireny Sendlerowej
+Ulica Irysowa
+Ulica Iwana Bunina
+Ulica Iwana Kryłowa
+Ulica Iwana Turgieniewa
+Ulica Iwonicka
+Ulica Izaaka Newtona
+Ulica Izbicka
+Ulica Jabłonkowska
+Ulica Jachtowa
+Skwer Jacka Hałasika
+Ulica Jacka Kaczmarskiego
+Ulica Jacka Malczewskiego
+Ulica Jacka Rychlewskiego
+Skwer Jacka Wiesiołowskiego
+Ulica Jadwigi Badowskiej-Muszyńskiej
+Skwer Jadwigi Gulińskiej
+Ulica Jadwigi Łuszczewskiej
+Ulica Jadwigi Wajsówny
+Ulica Jadwigi Żylińskiej
+Osiedle Jagiellońskie
+Ulica Jagodowa
+Ulica Jakuba Krauthofera
+Ulica Jałowcowa
+Ulica Jana Baptysty Quadro
+Ulica Jana Brzechwy
+Ulica Jana Czekanowskiego
+Ulica Jana Czochralskiego
+Ulica Jana Długosza
+Ulica Jana Gorczyczewskiego
+Ulica Jana Grochmalickiego
+Ulica Jana Henryka Dąbrowskiego
+Osiedle Jana III Sobieskiego
+Ulica Jana Karskiego
+Park Jana Kasprowicza
+Ulica Jana Kasprowicza
+Ulica Jana Kassyusza
+Ulica Jana Keplera
+Ulica Jana Kilińskiego
+Ulica Jana Kochanowskiego
+Ulica Jana Koźmiana
+Ulica Jana Kułakowskiego
+Ulica Jana Lubrańskiego
+Ulica Jana Ludygi-Laskowskiego
+Ulica Jana Maklakiewicza
+Ulica Jana Matejki
+Ulica Jana Nagórskiego
+Rondo Jana Nowaka-Jeziorańskiego
+Ulica Jana Ostroroga
+Ulica Jana Parandowskiego
+Ulica Jana Pawła II
+Park Jana Pawła II
+Ulica Jana Piekałkiewicza
+Ulica Jana Pietrusińskiego
+Aleja Jana Piwnika
+Ulica Jana Rakowicza
+Ulica Jana Rodowicza
+Ulica Jana Rymarkiewicza
+Ulica Jana Skrzetuskiego
+Ulica Jana Sokołowskiego
+Ulica Jana Spychalskiego
+Skwer Jana Stryczyńskiego
+Skwer Jana Suwarta
+Ulica Jana Sztaudyngera
+Ulica Jana Umińskiego
+Ulica Jana Wiencka
+Ulica Jana Wojkiewicza
+Ulica Jana Żupańskiego
+Ulica Janikowska
+Ulica Janiny Dzierżykraj-Morawskiej
+Ulica Janiny I Jana Żniniewiczów
+Ulica Janiny Kwaśniewskiej
+Ulica Janiny Omańkowskiej
+Ulica Janiny Porazińskiej
+Ulica Janisławy
+Ulica Janosika
+Ulica Janowo
+Ulica Janowska
+Ulica Janusza Korczaka
+Ulica Janusza Kulasa
+Ulica Janusza Meissnera
+Ulica Janusza Szpotańskiego
+Ulica Janusza Zeylanda
+Skwer Janusza Ziółkowskiego
+Ulica Jaraczewska
+Ulica Jarmużowa
+Ulica Jarocińska
+Ulica Jarogniewa Drwęskiego
+Park Jarogniewa I Izabeli Drwęskich
+Ulica Jaromira
+Ulica Jarosława Iwaszkiewicza
+Ulica Jarosława Maciejewskiego
+Ulica Jarosława Ziętary
+Ulica Jarosławska
+Ulica Jarowa
+Ulica Jarzębowa
+Ulica Jasielska
+Ulica Jaskiniowa
+Ulica Jaskółcza
+Ulica Jasna
+Ulica Jasna Rola
+Ulica Jasne Błonie
+Ulica Jaspisowa
+Ulica Jastarnicka
+Ulica Jastrowska
+Ulica Jastrzębia
+Ulica Jaśminowa
+Ulica Jawornicka
+Ulica Jaworowa
+Ulica Jedlicka
+Ulica Jeleniogórska
+Ulica Jelitkowska
+Ulica Jemiołowa
+Ulica Jerzego Bajana
+Ulica Jerzego Jurandota
+Skwer Jerzego Kurczewskiego
+Skwer Jerzego Mielocha
+Ulica Jerzego Miliana
+Ulica Jerzego Różyckiego
+Ulica Jerzego Suszki
+Ulica Jerzego Waldorffa
+Ulica Jesienna
+Ulica Jesionowa
+Ulica Jeziorańska
+Ulica Jeżycka
+Rynek Jeżycki
+Ulica Jeżynowa
+Ulica Jęczmienna
+Ulica Jędrzejowska
+Ulica Joachima Lelewela
+Ulica Jodłowa
+Ulica Johanna Wolfganga Goethego
+Ulica Józefa Burszty
+Ulica Józefa Chełmońskiego
+Ulica Józefa Chociszewskiego
+Rondo Józefa Czapskiego
+Ulica Józefa Dowbora-Muśnickiego
+Ulica Józefa Edwarda Grobelnego
+Ulica Józefa Garczyńskiego
+Skwer Józefa Granatowicza
+Ulica Józefa Hallera
+Ulica Józefa Janiszewskiego
+Ulica Józefa Kostrzewskiego
+Ulica Józefa Kościelskiego
+Ulica Józefa Kraszewskiego
+Ulica Józefa Łęgowskiego
+Ulica Józefa Łukaszewicza
+Ulica Józefa Paczoskiego
+Ulica Józefa Piłsudskiego
+Skwer Józefa Przesławskiego
+Ulica Józefa Przybylskiego
+Ulica Józefa Rivolego
+Ulica Józefa Rogalińskiego
+Ulica Józefa Rymera
+Ulica Józefa Sowińskiego
+Ulica Józefa Strusia
+Rondo Józefa Vogla
+Ulica Józefa Węglarza
+Ulica Józefa Wrońskiego
+Ulica Józefa Wybickiego
+Ulica Józefa Żymierskiego
+Ulica Józwy Butryma
+Ulica Jugosłowiańska
+Ulica Juliana Niemcewicza
+Ulica Juliana Tuwima
+Ulica Julii I Antoniego Wojkowskich
+Ulica Juliusza Kossaka
+Ulica Juliusza Osterwy
+Ulica Juliusza Słowackiego
+Ulica Junacka
+Ulica Junikowska
+Ulica Juracka
+Ulica Juranda
+Ulica Juraszów
+Park Jurija Gagarina
+Ulica Jutrosińska
+Ulica Jutrzenka
+Ulica Juwenalisa
+Ulica Kabaczkowa
+Ulica Kacza
+Ulica Kaczeńcowa
+Ulica Kadecka
+Ulica Kajakowa
+Ulica Kalinowa
+Ulica Kaliowa
+Ulica Kaliska
+Ulica Kamienicka
+Ulica Kamienna
+Ulica Kamiennogórska
+Ulica Kamieńska
+Ulica Kanałowa
+Ulica Kanclerska
+Ulica Kapitańska
+Rondo Kaponiera
+Ulica Kaprala Wojtka
+Ulica Karawelowa
+Ulica Karbowska
+Ulica Kargowska
+Ulica Karkonoska
+Ulica Karlińska
+Ulica Karmelicka
+Ulica Karmelowa
+Ulica Karola Buczka
+Ulica Karola Bunscha
+Ulica Karola Dickensa
+Skwer Karola Hoffmanna
+Ulica Karola Irzykowskiego
+Ulica Karola Kurpińskiego
+Ulica Karola Libelta
+Park Karola Marcinkowskiego
+Ulica Karola Szymanowskiego
+Ulica Karpacka
+Ulica Karpia
+Ulica Karpicka
+Ulica Karsińska
+Ulica Kartuska
+Ulica Karwieńska
+Ulica Kaspra Drużbickiego
+Skwer Kaspra Goskiego
+Ulica Kastylijska
+Ulica Kasztanowa
+Ulica Kasztelańska
+Ulica Kaszubska
+Ulica Katalońska
+Ulica Katowicka
+Ulica Kawaleryjska
+Ulica Kazimiery Iłłakowiczówny
+Ulica Kazimierza Ajdukiewicza
+Ulica Kazimierza Brandysa
+Ulica Kazimierza Brossa
+Ulica Kazimierza Drewnowskiego
+Skwer Kazimierza I Włodzimierza Okoniewskich
+Ulica Kazimierza Jarochowskiego
+Ulica Kazimierza Kantaka
+Ulica Kazimierza Mielęckiego
+Ulica Kazimierza Nieżychowskiego
+Skwer Kazimierza Nowaka
+Plac Kazimierza Nowakowskiego
+Ulica Kazimierza Pułaskiego
+Ulica Kazimierza Pużaka
+Ulica Kazimierza Spornego
+Ulica Kazimierza Szałasa
+Skwer Kazimierza Szulca
+Ulica Kazimierza Tymienieckiego
+Ulica Kazimierza Wielkiego
+Ulica Kazimierza Wierzyńskiego
+Ulica Kącik
+Ulica Kąpielowa
+Ulica Kcyńska
+Ulica Ketlinga
+Ulica Kępa
+Ulica Kępińska
+Ulica Kielecka
+Ulica Kiemliczów
+Ulica Kierska
+Ulica Kirchholmska
+Ulica Klasztorna
+Ulica Klaudyny Potockiej
+Ulica Klemensa Janickiego
+Ulica Klemensa Mikuły
+Ulica Klementyny Hoffmanowej
+Skwer Klementyny Śliwińskiej
+Ulica Klenowska
+Ulica Klimatyczna
+Ulica Klimontowska
+Ulica Klin
+Ulica Klinkierowa
+Ulica Klonowa
+Ulica Kluczborska
+Ulica Kłońska
+Ulica Kłosowa
+Ulica Kłuszyńska
+Ulica Kmicica
+Ulica Kmieca
+Ulica Kminkowa
+Ulica Knyszyn
+Ulica Kobylepole
+Ulica Kobylińska
+Ulica Kocankowa
+Ulica Kociewska
+Ulica Kokosowa
+Ulica Kolbuszowska
+Plac Kolegiacki
+Ulica Kolejowa
+Ulica Kolorowa
+Ulica Kolska
+Ulica Kołobrzeska
+Ulica Kołodzieja
+Ulica Komandoria
+Ulica Komandorska
+Ulica Komornicka
+Ulica Konarowa
+Ulica Konarzewska
+Ulica Kondratija Rylejewa
+Ulica Konfederacka
+Ulica Konińska
+Ulica Konopna
+Ulica Konstancji Łubieńskiej
+Ulica Konstantego Hrynakowskiego
+Ulica Konstantego Ildefonsa Gałczyńskiego
+Ulica Konstantego Skąpskiego
+Ulica Konstantego Troczyńskiego
+Skwer Konstelacji
+Ulica Konwaliowa
+Ulica Kopanina
+Ulica Kopciuszka
+Ulica Kopcowa
+Ulica Koprowa
+Ulica Koprzywnicka
+Ulica Kopylnik
+Ulica Koralowa
+Ulica Korbielowska
+Ulica Korczyńska
+Ulica Kormorana
+Ulica Kornela Makuszyńskiego
+Ulica Koronkarska
+Ulica Koronna
+Ulica Koronowska
+Ulica Korwetowa
+Ulica Korzenna
+Ulica Kosiarzy
+Osiedle Kosmonautów
+Ulica Kosowska
+Ulica Kostrzyńska
+Park Kosynierów
+Ulica Kosynierska
+Ulica Koszalińska
+Ulica Kościańska
+Ulica Kościelna
+Ulica Kościerzyńska
+Ulica Kotlarska
+Ulica Kotlińska
+Ulica Kotowo
+Ulica Kowalewicka
+Ulica Kowalska
+Ulica Kowarska
+Ulica Kozia
+Ulica Kozienicka
+Ulica Koziorożca
+Ulica Koźmińska
+Ulica Kórnicka
+Ulica Krajenecka
+Ulica Krakowiaków i Górali
+Ulica Krakowska
+Ulica Kramarska
+Ulica Krańcowa
+Ulica Krapkowicka
+Ulica Krasnoludków
+Ulica Kraśnicka
+Ulica Kresowa
+Ulica Krobska
+Ulica Krokusowa
+Ulica Krośnieńska
+Ulica Krośniewicka
+Ulica Krotoszyńska
+Aleja Króla Przemysła II
+Ulica Królewny Śnieżki
+Ulica Królewska
+Ulica Królowej Jadwigi
+Rondo Królowej Ryksy Elżbiety
+Ulica Krótka
+Ulica Krucza
+Ulica Kruszwicka
+Ulica Krwawnikowa
+Ulica Krynicka
+Skwer Krystyny Skarbek
+Ulica Kryształowa
+Ulica Krywiczańska
+Ulica Krzemieniowa
+Ulica Krzepicka
+Ulica Krzesiny
+Rondo Krzesiny
+Ulica Krzeszowicka
+Ulica Krzysztofa Arciszewskiego
+Ulica Krzysztofa Kamila Baczyńskiego
+Aleja Krzysztofa Komedy
+Rondo Krzysztofa Skubiszewskiego
+Ulica Krzysztofa Żegockiego
+Ulica Krzywa
+Ulica Krzywińska
+Ulica Krzyżowa
+Ulica Krzyżówki
+Rondo Ks. Antoniego Sroki
+Ulica Ks. Bolesława Sulka
+Ulica Ks. Edwarda Nawrota
+Park Ks. Feliksa Michalskiego
+Ulica Ks. Ignacego Posadzego
+Ulica Ks. Jakuba Wujka
+Ulica Ks. Jana Twardowskiego
+Osiedle Ks. Jerzego Popiełuszki
+Park Ks. Józefa Jasińskiego
+Ulica Ks. Kazimierza Waseli
+Aleja Ks. Mieczysława Radziejewskiego
+Skwer Ks. Mjra Rudolfa Marszałka
+Ulica Ks. Stanisława Brzóski
+Rondo Ks. Stanisława Kałka
+Park Ks. Tadeusza Kirschke
+Ulica Ks. Tomasza Maćkowiaka
+Ulica Ks. Zdzisława Bernata
+Ulica Ksawerego Zakrzewskiego
+Ulica Książęca
+Ulica Księcia Józefa
+Ulica Księcia Mieszka I
+Ulica Księżycowa
+Ulica Ku Cytadeli
+Ulica Ku Dębinie
+Ulica Kudowska
+Ulica Kujawska
+Ulica Kukułcza
+Ulica Kupały
+Ulica Kurlandzka
+Ulica Kurpiowska
+Ulica Kurzanoga
+Ulica Kutnowska
+Ulica Kuźnicza
+Ulica Kwarcowa
+Ulica Kwiatowa
+Ulica Kwidzyńska
+Ulica Kwiryny
+Ulica Lachowicka
+Ulica Laskowa
+Ulica Latawcowa
+Ulica Laudańska
+Ulica Laurowa
+Ulica Lawendowa
+Ulica Lazurowa
+Ulica Lądecka
+Ulica Lebiodowa
+Osiedle Lecha
+Skwer Lecha Molewskiego
+Ulica Lechicka
+Ulica Lednicka
+Ulica Legnicka
+Ulica Lemierzycka
+Skwer Leona I Aleksandra Janta-Połczyńskich
+Ulica Leona Mroczkiewicza
+Ulica Leona Prauzińskiego
+Ulica Leona Przyłuskiego
+Skwer Leona Wyczółkowskiego
+Ulica Leopolda Okulickiego
+Ulica Leopolda Staffa
+Ulica Leopolda Tyrmanda
+Ulica Leska
+Ulica Leszczyńska
+Ulica Leszka
+Ulica Leszka Proroka
+Ulica Leśna
+Ulica Leśników
+Ulica Leśnowolska
+Ulica Leśnych Skrzatów
+Ulica Letnia
+Ulica Letniskowa
+Ulica Lewkoniowa
+Ulica Leżajska
+Ulica Lęborska
+Ulica Lidzbarska
+Ulica Lidzka
+Ulica Liliowa
+Ulica Limanowska
+Ulica Limbowa
+Ulica Limonkowa
+Ulica Lipnicka
+Ulica Lipowa
+Plac Lipowy
+Ulica Liryczna
+Ulica Lisa Witalisa
+Ulica Lisia
+Ulica Listopadowa
+Ulica Liściasta
+Ulica Literacka
+Ulica Litewska
+Ulica Lodowa
+Ulica Longinusa Podbipięty
+Ulica Lotaryńska
+Osiedle Lotnictwa Polskiego
+Ulica Lotnicza
+Ulica Lotników 302. Dywizjonu Poznańskiego
+Osiedle Lotników Wielkopolskich
+Ulica Lotosowa
+Ulica Luba
+Ulica Lubartowska
+Ulica Lubczykowa
+Ulica Lubelska
+Ulica Lubiatowska
+Ulica Lubieńska
+Ulica Lubniewicka
+Ulica Lubomierska
+Ulica Lubońska
+Ulica Lubosińska
+Ulica Lubowska
+Ulica Lubuszańska
+Ulica Lucjana Ballenstedta
+Ulica Lucyny Sieciechowiczowej
+Ulica Ludgardy
+Ulica Ludmiły
+Ulica Ludmiły Krakowieckiej
+Ulica Ludosławy
+Ulica Ludwika Braille'a
+Ulica Ludwika Idzikowskiego
+Ulica Ludwika Krzywickiego
+Ulica Ludwika Solskiego
+Plac Ludwika Waryńskiego
+Ulica Ludwika Zamenhofa
+Ulica Ludwiki Dobrzyńskiej-Rybickiej
+Ulica Lukrecjusza
+Ulica Lutycka
+Ulica Lwa
+Ulica Lwa Tołstoja
+Ulica Lwowska
+Ulica Łabędzia
+Ulica Łabiszyńska
+Ulica Łacina
+Ulica Łady
+Ulica Łagiewnicka
+Ulica Łagodna
+Ulica Łagowska
+Ulica Łanowa
+Ulica Łańcucka
+Ulica Ławica
+Rondo Ławickich Wydm
+Rynek Łazarski
+Ulica Łazienna
+Ulica Łąkowa
+Ulica Łebska
+Ulica Łęczycka
+Ulica Łęgi Dębińskie
+Ulica Łobeska
+Ulica Łobżenicka
+Ulica Łomnicka
+Ulica Łomżyńska
+Ulica Łopawska
+Ulica Łopianowa
+Ulica Łosiowa
+Ulica Łotewska
+Ulica Łowicka
+Ulica Łozowa
+Ulica Łódzka
+Ulica Łubinowa
+Ulica Łucji Danielewskiej
+Ulica Łuczanowska
+Ulica Łuczkowska
+Ulica Ługańska
+Skwer Łukasza Horowskiego
+Ulica Łupowska
+Ulica Łużycka
+Ulica Łyski
+Ulica Łysogórska
+Ulica Łysy Młyn
+Ulica Macieja Palacza
+Ulica Macieja Rataja
+Skwer Macieja Zawiei
+Ulica Maciejkowa
+Ulica Macierzankowa
+Ulica Madziarska
+Ulica Magnacka
+Ulica Magnoliowa
+Ulica Majerankowa
+Ulica Majowa
+Ulica Makoszowska
+Ulica Makowa
+Ulica Makowej Panienki
+Ulica Maków Polnych
+Skwer Maksymiliana Ciężkiego
+Ulica Maksymiliana Garsteckiego
+Ulica Maksymiliana Jackowskiego
+Ulica Malachitowa
+Ulica Malborska
+Ulica Malechowska
+Ulica Malinowa
+Ulica Maltańska
+Ulica Malwowa
+Ulica Mała
+Ulica Małe Garbary
+Ulica Małopolska
+Ulica Małoszyńska
+Ulica Mandarynkowa
+Ulica Maratońska
+Ulica Marcelego Mottego
+Ulica Marcelin Fort VII
+Ulica Marcelińska
+Ulica Marcina Kasprzaka
+Ulica Marcina Rożka
+Ulica Margaretkowa
+Ulica Margonińska
+Ulica Mariacka
+Ulica Mariampolska
+Ulica Mariana Jaroczyńskiego
+Ulica Mariana Langiewicza
+Ulica Mariana Rejewskiego
+Ulica Mariana Smoluchowskiego
+Skwer Marianny Marszałkowskiej-Kaniewskiej
+Ulica Marii Aleksandrowicz
+Ulica Marii Bohuszewiczówny
+Ulica Marii Dulębianki
+Ulica Marii I Celestyna Rydlewskich
+Skwer Marii I Lecha Kaczyńskich
+Ulica Marii Konopnickiej
+Ulica Marii Kuncewiczowej
+Ulica Marii Lange
+Skwer Marii Paradowskiej
+Ulica Marii Pawlikowskiej-Jasnorzewskiej
+Skwer Marii Rataj
+Ulica Marii Rodziewiczówny
+Plac Marii Skłodowskiej-Curie
+Ulica Marii Swinarskiej
+Ulica Marii Szembekowej
+Ulica Marii Szmytówny
+Ulica Marii Wicherkiewicz
+Skwer Marii Zamoyskiej
+Ulica Marka Hłaski
+Ulica Marklowicka
+Ulica Marszałkowska
+Ulica Marynarska
+Osiedle Marysieńki
+Ulica Marzanny
+Ulica Maszewska
+Ulica Masztalarska
+Ulica Masztowa
+Ulica Maszynowa
+Ulica Mazowiecka
+Ulica Mazurska
+Ulica Mączna
+Ulica Melchiora Wańkowicza
+Ulica Meliorantów
+Ulica Melisowa
+Ulica Metalowa
+Ulica Meteorytowa
+Ulica Mewy
+Ulica Mgielna
+Ulica Miastkowska
+Ulica Michaiła Bułhakowa
+Ulica Michaiła Lermontowa
+Ulica Michaliny Stefanowskiej
+Ulica Michała Bałuckiego
+Ulica Michała Barzyńskiego
+Ulica Michała Drzymały
+Ulica Michała Kajki
+Ulica Michała Ossowskiego
+Ulica Michała Sobeskiego
+Ulica Michała Tokarzewskiego
+Skwer Michała Tomiaka
+Ulica Michała Wołodyjowskiego
+Ulica Michałowo
+Ulica Michałowska
+Ulica Miechowska
+Ulica Miecznikowska
+Ulica Mieczykowa
+Ulica Mieczysława Jastruna
+Ulica Mieczysława Niedziałkowskiego
+Ulica Mieczysława Palucha
+Ulica Mieczysława Rawicz-Mysłowskiego
+Ulica Mieczysławy Ruxerówny
+Ulica Miedziana
+Ulica Mielecka
+Ulica Mieleszyńska
+Ulica Mieszkowska
+Ulica Międzyborska
+Ulica Międzychodzka
+Ulica Międzyleska
+Plac Międzymoście
+Ulica Międzyzdrojska
+Ulica Miętowa
+Ulica Migdałowa
+Ulica Mikołaja Dobrzyckiego
+Osiedle Mikołaja Kopernika
+Ulica Mikołaja Kopernika
+Ulica Mikołaja Reja
+Ulica Mikołaja Rudnickiego
+Ulica Mikołajecka
+Ulica Mikołowska
+Ulica Mikstacka
+Skwer Milana Kwiatkowskiego
+Ulica Milczańska
+Ulica Milicka
+Ulica Miła
+Ulica Miłosławska
+Ulica Miłowita
+Ulica Minikowo
+Ulica Mińska
+Ulica Miodowa
+Ulica Mirabelkowa
+Ulica Mirosławiecka
+Ulica Mirosławy
+Ulica Mirtowa
+Ulica Misia Uszatka
+Ulica Miśnieńska
+Ulica Mleczowa
+Ulica Mławska
+Ulica Młodnikowa
+Ulica Młyńska
+Ulica Modlińska
+Ulica Modra
+Ulica Modrakowa
+Ulica Modrzewiowa
+Ulica Mogileńska
+Ulica Mokra
+Ulica Moliera
+Ulica Mołdawska
+Ulica Moniki Cegłowskiej
+Ulica Moniki Gruchmanowej
+Rondo Moraczewskich
+Ulica Morasko
+Ulica Morawska
+Ulica Morelowa
+Ulica Morenowa
+Ulica Morska
+Ulica Morszyńska
+Ulica Morwowa
+Ulica Moryńska
+Ulica Morzyczańska
+most Biskupa Jordana
+Most Bolesława Chrobrego
+Most Dębiński
+Most Dworcowy
+Most Królowej Jadwigi
+Most Lecha
+Most Lucjana Ballenstedta
+Most Mieszka I
+most Przemysła I
+most Przemysła I
+Most św. Rocha
+Most Teatralny
+Most Uniwersytecki
+Ulica Mostowa
+Ulica Mrągowska
+Ulica Mrowińska
+Ulica Mroźna
+Ulica Mrzeżyńska
+Ulica Mścibora
+Ulica Murawa
+Ulica Murna
+Ulica Muszkowska
+Ulica Muszyńska
+Ulica Mylna
+Ulica Mysłowicka
+Ulica Myśliborska
+Ulica Myśliwska
+Ulica Na Dołku
+Ulica Na Miasteczku
+Osiedle Na Murawie
+Ulica Na Podgórniku
+Ulica Na Skarpie
+Ulica Na Stoku
+Ulica Na Szańcach
+Ulica Na Uboczu
+Ulica Nad Bogdanką
+Ulica Nad Jeziorem
+Ulica Nad Krzesinką
+Ulica Nad Łężynką
+Ulica Nad Miedzą
+Ulica Nad Pokrzywką
+Ulica Nad Potokiem
+Ulica Nad Przeźmierką
+Ulica Nad Różanym Potokiem
+Ulica Nad Seganką
+Ulica Nad Spławką
+Ulica Nad Starynką
+Ulica Nad Wierzbakiem
+Ulica Nadbrzeże
+Ulica Nadolnik
+Ulica Nadwarciańska
+Ulica Nagietkowa
+Ulica Nagłowicka
+Ulica Nakielska
+Ulica Nałęczowska
+Ulica Namysłowska
+Ulica Napoleońska
+Ulica Naramowicka
+Ulica Narcyzowa
+Ulica Narcyzy Żmichowskiej
+Ulica Narewska
+Ulica Nasienna
+Ulica Nasturcjowa
+Ulica Nawigacyjna
+Ulica Nefrytowa
+Ulica Nektarynkowa
+Ulica Nidziańska
+Ulica Niebieska
+Ulica Niecała
+Ulica Niemeńska
+Aleja Niepodległości
+Ulica Niepołomicka
+Ulica Niestachowska
+Ulica Nieszawska
+Skwer Niezależnego Zrzeszenia Studentów
+Ulica Niezłomnych
+Ulica Nikodema Pajzderskiego
+Ulica Nikołaja Gogola
+Ulica Niska
+Ulica Nizinna
+Ulica Niżańska
+Ulica Normandzka
+Ulica Nostrzykowa
+Ulica Notecka
+Ulica Nowe Zagórze
+Ulica Nowina
+Ulica Nowogrodzka
+Ulica Nowokramska
+Ulica Nowosądecka
+Ulica Nowosolska
+Ulica Nowotarska
+Ulica Nowotomyska
+Ulica Nowy Świat
+Ulica Nuny I Bolesława Szczurkiewiczów
+Skwer O. Czesława Białka
+Ulica O. Honoriusza Kowalczyka
+Skwer O. Jana Góry
+Ulica O. Mariana Żelazka
+Ulica Obodrzycka
+Ulica Obornicka
+Rondo Obornickie
+Ulica Obozowa
+Ulica Obronna
+Rondo Obrońców Grodna
+Ulica Obrońców Tobruku
+Skwer Obrońców Ukrainy 2022
+Ulica Obrzańska
+Ulica Obrzeże
+Ulica Obrzyca
+Ulica Obrzycka
+Ulica Ochota
+Ulica Odległa
+Ulica Odolanowska
+Ulica Odrzycka
+Ulica Ognik
+Ulica Ogórkowa
+Ulica Ogrodowa
+Park Ogród Zamkowy im. Ofiar Katynia i Sybiru
+Ulica Ojcowska
+Ulica Okolewo
+Ulica Okonecka
+Ulica Okopowa
+Ulica Okólna
+Ulica Okrętowa
+Ulica Olchowa
+Ulica Olecka
+Ulica Oleńki Billewiczówny
+Ulica Oleszycka
+Ulica Oleśnicka
+Ulica Olgi Boznańskiej
+Ulica Olgi Sawickiej
+"Ulica Olgi Sipowicz ""Kory"""
+Ulica Olgi Sławskiej-Lipczyńskiej
+Ulica Olimpijska
+Ulica Oliwkowa
+Ulica Oliwska
+Ulica Olkuska
+Ulica Olsztyńska
+Ulica Olszynka
+Ulica Olzańska
+Ulica Oławska
+Ulica Onufrego Kopczyńskiego
+Ulica Onufrego Zagłoby
+Ulica Opalenicka
+Ulica Opalowa
+Ulica Opatowska
+Ulica Opawska
+Ulica Opłotki
+Ulica Opoczyńska
+Ulica Opolska
+Ulica Oranżeryjna
+Plac Orawski
+Aleja Orderu Uśmiechu
+Ulica Orężna
+Ulica Orla
+Ulica Orląt
+Osiedle Orła Białego
+Ulica Orłowska
+Ulica Orna
+Ulica Ornecka
+Ulica Orszańska
+Ulica Orzechowa
+Ulica Osiecka
+Ulica Osinowa
+Ulica Oskara Kolberga
+Ulica Oskierki
+Ulica Ostatnia
+Ulica Ostrobramska
+Ulica Ostrołęcka
+Ulica Ostrowska
+Ulica Ostródzka
+Ulica Ostrów Tumski
+Ulica Ostrówek
+Ulica Ostrzeszowska
+Osiedle Oświecenia
+Ulica Oświęcimska
+Ulica Otwarta
+Ulica Otwocka
+Ulica Owcza
+Ulica Owczarska
+Ulica Owidiusza
+Ulica Ownicka
+Ulica Owocowa
+Ulica Owsiana
+Ulica Ozimina
+Ulica Ożarowska
+Ulica Pabianicka
+Ulica Paczkowska
+Ulica Pagórkowa
+Ulica Pałucka
+Ulica Pamiątkowa
+Ulica Pana Kleksa
+Ulica Pana Twardowskiego
+Ulica Panny
+Ulica Panny Marii
+Ulica Papuszy
+Ulica Parkowa
+Ulica Partyzancka
+Ulica Pasieka
+Ulica Pasłęcka
+Ulica Pastelowa
+Ulica Pasterska
+Ulica Pastewna
+Ulica Patrice'A Lumumby
+Ulica Pawia
+Ulica Pawła Cymsa
+Park Pawła Edmunda Strzeleckiego
+Ulica Pawła Strzeleckiego
+Ulica Pawła Włodkowica
+Ulica Pawła Zołotowa
+Ulica Pawłowicka
+Ulica Pelplińska
+Ulica Perkoza
+Ulica Perkuna
+Ulica Perłowa
+Ulica Perłowska
+Ulica Perzycka
+Ulica Petera Mansfelda
+Ulica Petuniowa
+Ulica Piargowa
+Ulica Piaskowa
+Ulica Piastowska
+Osiedle Piastowskie
+Ulica Piaśnicka
+Rondo Piątkowo
+Ulica Piątkowska
+Ulica Piekary
+Ulica Pierwiosnkowa
+Ulica Pietruszkowa
+Ulica Piękna
+Ulica Pigwowa
+Ulica Pilicka
+Ulica Pilotów
+Ulica Pilska
+Ulica Piławska
+Ulica Pińczowska
+Ulica Piołunowa
+Ulica Pionierska
+Ulica Piotra Skargi
+Ulica Piotra Ściegiennego
+Ulica Piotra Tomickiego
+Ulica Piotra Wawrzyniaka
+Ulica Piotra Wysockiego
+Ulica Piotrowo
+Ulica Piotrowska
+Ulica Pistacjowa
+Ulica Piwna
+Ulica Piwoniowa
+Ulica Platanowa
+Ulica Plauta
+Ulica Plebańska
+Ulica Pleszewska
+Ulica Plonowa
+Ulica Płocka
+Ulica Płomienna
+Ulica Płowiecka
+Ulica Pniewska
+Ulica Pobiedziska
+Ulica Pobielska
+Ulica Pochyła
+Ulica Pod Lasem
+Aleja Pod Lipami
+Osiedle Pod Lipami
+Ulica Podbiałowa
+Ulica Podbórska
+Ulica Podchorążych
+Ulica Podgajska
+Ulica Podgórna
+Ulica Podgórze
+Ulica Podhalańska
+Ulica Podjaryszki
+Ulica Podjazdowa
+Ulica Podkomorska
+Ulica Podlaska
+Ulica Podleśna
+Ulica Podmiejska
+Ulica Podmokła
+Ulica Podolańska
+Ulica Podolska
+Ulica Podstolińska
+Ulica Podwale
+Ulica Poetycka
+Ulica Pogodna
+Ulica Pogorzelska
+Ulica Pokrzywno
+Osiedle Polan
+Ulica Polanicka
+Ulica Polanka
+Ulica Polanowska
+Ulica Polańska
+Ulica Polarna
+Ulica Poleska
+Ulica Poli Gojawiczyńskiej
+Skwer Policji Państwowej II RP
+Ulica Policka
+Ulica Poligonowa
+Ulica Polna
+Ulica Polska
+Skwer Polskich Olimpijek i Olimpijczyków
+Ulica Połabska
+Ulica Połaniecka
+Ulica Połczyńska
+Ulica Południowa
+Ulica Pomarańczowa
+Ulica Pomidorowa
+Ulica Pomorska
+Plac Pomorski
+Ulica Poniecka
+Ulica Popiela
+Ulica Poplińskich
+Ulica Popradzka
+Ulica Poprzeczna
+Ulica Popularna
+Ulica Por. Janiny Lewandowskiej
+Ulica Poranek
+Ulica Porannej Rosy
+Ulica Poręba
+Ulica Poronińska
+Ulica Portowa
+Ulica Porzeczkowa
+Ulica Pośród Drzew
+Ulica Poświata
+Ulica Powidzka
+Ulica Powozowa
+Osiedle Powstań Narodowych
+Osiedle Powstańców Śląskich
+Osiedle Powstańców Warszawy
+Ulica Powstańców Wielkopolskich
+Ulica Powstańcza
+Plac Powszechnej Wystawy Krajowej
+Ulica Pozdawnicka
+Ulica Poziomkowa
+Ulica Poznańska
+Rondo Poznańskich Ogrodników
+Ulica Poznańskie Sady
+Skwer Poznańskiego Towarzystwa Przyjaciół Nauk
+Ulica Północna
+Ulica Półwiejska
+Ulica Prabucka
+Aleja Praw Dziecka
+Aleja Praw Dziecka
+Aleja Praw Kobiet
+Ulica Prądnicka
+Ulica Promienista
+Ulica Promyk
+Ulica Prosta
+Ulica Proszowicka
+Ulica Prośnicka
+Ulica Prowansalska
+Ulica Prusimska
+Ulica Pruszkowska
+Ulica Prużańska
+Ulica Prymasa Augusta Hlonda
+Ulica Prymasa Stefana Wyszyńskiego
+Ulica Przasnyska
+Ulica Prząśniczki
+Ulica Przebiśniegowa
+Ulica Przedborska
+Ulica Przedpole
+Ulica Przedwiośnia
+Ulica Przelot
+Ulica Przełajowa
+Ulica Przełęcz
+Ulica Przełom
+Ulica Przemyska
+Osiedle Przemysława
+Plac Przemysława Bystrzyckiego
+Ulica Przemysłowa
+Ulica Przepadek
+Ulica Przepiórcza
+Ulica Przeskok
+Ulica Przesmyk
+Ulica Prześwit
+Ulica Przeworska
+Ulica Przy Autostradzie
+Ulica Przy Dolinie
+Ulica Przy Lotnisku
+Ulica Przybrodzka
+Ulica Przygraniczna
+Ulica Przyjazna
+Osiedle Przyjaźni
+Skwer Przyjaźni Polsko-Węgierskiej
+Ulica Przyjemna
+Ulica Przylaszczkowa
+Ulica Przystań
+Ulica Przytoczna
+Ulica Przytulna
+Ulica Psarskie
+Ulica Pszczelna
+Ulica Pszczyńska
+Ulica Pszenna
+Ulica Ptasia
+Ulica Ptaszkowska
+Ulica Pucka
+Ulica Puławska
+Ulica Pułtuska
+Ulica Pusta
+Ulica Pustkowska
+Ulica Pyrzyczańska
+Ulica Rabczańska
+Skwer Rabina Akivy Egera
+Ulica Raciborska
+Ulica Racjonalizatorów
+Ulica Racławicka
+Ulica Radlińska
+Ulica Radłowa
+Ulica Radojewo
+Ulica Radomska
+Ulica Radosna
+Ulica Radowita
+Ulica Radyńska
+Ulica Radziejowska
+Ulica Radziwoja
+Ulica Raka
+Ulica Rakietowa
+Ulica Rakoniewicka
+Ulica Ranowska
+Ulica Raszkowska
+Ulica Raszyńska
+Rondo Rataje
+Ulica Rataje
+Park Rataje
+Ulica Ratuszowa
+Ulica Rawicka
+Ulica Rdestowa
+Ulica Reczeńska
+Ulica Redarowska
+Ulica Regatowa
+Ulica Reglowa
+Ulica Reknicka
+Ulica Rekreacyjna
+Ulica Rembertowska
+Ulica Retmańska
+Ulica Rewalska
+Ulica Rezedowa
+Ulica Roberta Kocha
+Ulica Robocza
+Ulica Rocha Kowalskiego
+Ulica Rodawska
+Park Rodziny Stablewskich
+Ulica Rodzynkowa
+Ulica Rogera Sławskiego
+Ulica Rogowska
+Ulica Rogozińska
+Ulica Rojna
+Ulica Rokietnicka
+Ulica Rokity
+Ulica Rolna
+Ulica Romana Abrahama
+Ulica Romana Brandstaettera
+Ulica Romana Dmowskiego
+Ulica Romana Drewsa
+Ulica Romana Konkiewicza
+Ulica Romana Kozaka
+Park Romana Maciejewskiego
+Ulica Romana Maya
+Ulica Romana Pollaka
+Ulica Romana Szymańskiego
+Skwer Romana Ulatowskiego
+Skwer Romana Wilhelmiego
+Ulica Romana Wilkanowicza
+Ulica Romka Strzałkowskiego
+Ulica Romualda Traugutta
+Ulica Ropczycka
+Ulica Rosnowska
+Ulica Roślinna
+Ulica Rozewska
+Ulica Rozmarynowa
+Ulica Roztocka
+Ulica Rozwadowska
+Ulica Równa
+Ulica Różana
+Ulica Różany Targ
+Ulica Różyczkowa
+Ulica Rubież
+Ulica Rubinowa
+Ulica Ruczajowa
+Ulica Rudnicka
+Ulica Rudnicze
+Ulica Rudolfa Weigla
+Ulica Rudzka
+Ulica Rugijska
+Ulica Rumcajsa
+Ulica Rumiankowa
+Ulica Rumuńska
+Osiedle Rusa
+Ulica Ruska
+Ulica Ryb
+Ulica Rybaki
+Ulica Rybitwy
+Ulica Rybnicka
+Ulica Rybojadzka
+Ulica Rycerska
+Ulica Rydzowa
+Ulica Rydzyńska
+Ulica Rymanowska
+Ulica Rynarzewska
+Ulica Rynkowa
+Ulica Rypińska
+Ulica Rysia
+Ulica Ryszarda Berwińskiego
+Ulica Ryszarda Kaczorowskiego
+Skwer Ryszarda Kuklińskiego
+Skwer Ryszarda Schramma
+Ulica Rzeczańska
+Ulica Rzeczna
+Osiedle Rzeczypospolitej
+Ulica Rzepińska
+Ulica Rzeszowska
+Ulica Rzewieniowa
+Ulica Rzodkiewkowa
+Ulica Sabiny
+Ulica Sadnicka
+Ulica Sadowa
+Ulica Safony
+Ulica Salicka
+Ulica Samotna
+Ulica Samuela Lindego
+Ulica Sanatoryjna
+Ulica Sandomierska
+Ulica Sanocka
+Ulica Santocka
+Ulica Saperska
+Ulica Sarbinowska
+Ulica Sarmacka
+Ulica Sarnia
+Ulica Sasankowa
+Ulica Sąsiedzka
+Park Sąsiedzki
+Ulica Sebastiana Klonowica
+Ulica Selerowa
+Ulica Senatorska
+Ulica Seneki
+Ulica Serafitek
+Ulica Serbska
+Ulica Serdeczna
+Ulica Serwisowa
+Ulica Seweryna Mielżyńskiego
+Ulica Sędziwoja
+Ulica Sępia
+Ulica Sępoleńska
+Ulica Sianokosy
+Ulica Sianowska
+Ulica Siedliskowa
+Ulica Siedmiogrodzka
+Ulica Sielankowa
+Ulica Sielawy
+Ulica Sielska
+Ulica Sieradzka
+Ulica Sierakowska
+Ulica Sieroca
+Ulica Sierotki Marysi
+Ulica Sierpowa
+Ulica Sieweczki
+Ulica Siewierska
+Ulica Siewna
+Ulica Silniki
+Ulica Sióstr Misjonarek
+Ulica Skalna
+Ulica Skarszewska
+Skwer Skautów Powstańców Wielkopolskich
+Ulica Skawińska
+Ulica Skibowa
+Ulica Składowa
+Ulica Skoczowska
+Ulica Skorpiona
+Ulica Skośna
+Ulica Skotarska
+Ulica Skowronkowa
+Ulica Skórzewska
+Ulica Skrajna
+Ulica Skromna
+Ulica Skryta
+Ulica Skrzydlata
+Ulica Skrzypowa
+Ulica Skwierzyńska
+Ulica Sławińska
+Ulica Sławomira
+Ulica Słodyńska
+Ulica Słomiana
+Ulica Słoneczna
+Ulica Słonecznikowa
+Ulica Słonimska
+Ulica Słowiańska
+Osiedle Słowiańskie
+Ulica Słowicza
+Ulica Słubicka
+Ulica Słupecka
+Ulica Słupska
+Ulica Smardzewska
+Ulica Smoka Wawelskiego
+Ulica Smoleńska
+Ulica Smolna
+Ulica Smołdzinowska
+Ulica Snopowa
+Ulica Sobiesława
+Ulica Sobolowa
+Ulica Sobotecka
+Ulica Sochaczewska
+Ulica Sofii Lutosławskiej
+Ulica Sofoklesa
+Ulica Sokalska
+Ulica Sokoła
+Ulica Solecka
+Rondo Solidarności
+Ulica Solińska
+Ulica Solna
+Park Sołacki
+Ulica Sołtysia
+Ulica Sopocka
+Ulica Soroki
+Ulica Sosnowa
+Ulica Sośnicka
+Ulica Sowia
+Ulica Sowice
+Ulica Spacerowa
+Ulica Spadochronowa
+Ulica Spadzista
+Plac Spiski
+Ulica Spławie
+Ulica Spokojna
+Ulica Sporna
+Ulica Sportowa
+Skwer Sprawiedliwych Wśród Narodów Świata
+Ulica Srebrna
+Ulica Stalowa
+Ulica Stanisława Barańczaka
+Skwer Stanisława Bręczewskiego
+Ulica Stanisława Broniewskiego
+Ulica Stanisława Czernika
+Ulica Stanisława Dygata
+Ulica Stanisława Grochowiaka
+Ulica Stanisława Grzmota-Skotnickiego
+Ulica Stanisława Hejmowskiego
+Skwer Stanisława I Jana Chrościejowskich
+Ulica Stanisława Jachowicza
+Ulica Stanisława Jakiela
+Skwer Stanisława Jarzembowskiego
+Ulica Stanisława Karwowskiego
+Ulica Stanisława Kasznicy
+Ulica Stanisława Knapowskiego
+Ulica Stanisława Konarskiego
+Ulica Stanisława Królickiego
+Ulica Stanisława Kunickiego
+Ulica Stanisława Latwisa
+Ulica Stanisława Lema
+Ulica Stanisława Małachowskiego
+Ulica Stanisława Matyi
+Park Stanisława Moniuszki
+Skwer Stanisława Mrowińskiego
+Ulica Stanisława Niedbalskiego
+Ulica Stanisława Nowakowskiego
+Skwer Stanisława Pawlickiego
+Ulica Stanisława Pawłowskiego
+Skwer Stanisława Powalisza
+Ulica Stanisława Przybyszewskiego
+Ulica Stanisława Rostworowskiego
+Ulica Stanisława Rungego
+Ulica Stanisława Skalskiego
+Ulica Stanisława Skarżyńskiego
+Ulica Stanisława Staszica
+Ulica Stanisława Strugarka
+Ulica Stanisława Szczepanowskiego
+Ulica Stanisława Taczaka
+Ulica Stanisława Wachowiaka
+Ulica Stanisława Wiechowicza
+Ulica Stanisława Wigury
+Skwer Stanisława Wisłockiego
+Ulica Stanisława Worcella
+Ulica Stanisława Wyspiańskiego
+Ulica Stanisława Zwierzchowskiego
+Ulica Stara Cegielnia
+Ulica Starachowicka
+Park Stare Koryto Warty
+Osiedle Stare Żegrze
+Ulica Starkowska
+Ulica Starogardzka
+Ulica Starołęcka
+Rondo Starołęka
+Ulica Starosądecka
+Ulica Starowiejska
+Ulica Startowa
+Rynek Stary Rynek
+Ulica Staszowska
+Ulica Stawna
+Plac Stawny
+Ulica Stefana Balickiego
+Osiedle Stefana Batorego
+Ulica Stefana Czarnieckiego
+Ulica Stefana Drzewieckiego
+Ulica Stefana Grota-Roweckiego
+Ulica Stefana Jaracza
+Ulica Stefana Kisielewskiego
+Ulica Stefana Okrzei
+Skwer Stefana Piechockiego
+Ulica Stefana Poradowskiego
+Ulica Stefana Różyckiego
+Ulica Stefana Stoińskiego
+Plac Stefana Stuligrosza
+Ulica Stefana Szolca-Rogozińskiego
+Ulica Stefana Vrtela-Wierczyńskiego
+Ulica Stefana Żeromskiego
+Ulica Stefanii Sempołowskiej
+Ulica Stefanii Wojtulanis-Karpińskiej
+Ulica Stefanii Wołynki
+Ulica Sterowa
+Ulica Stewnicka
+Ulica Stęszewska
+Ulica Stobnicka
+Ulica Stobrawska
+Ulica Stokrotkowa
+Ulica Stolarska
+Ulica Storczykowa
+Ulica Straży Ludowej
+Ulica Strykowska
+Ulica Strzałkowska
+Ulica Strzałowa
+Ulica Strzecha
+Ulica Strzegomska
+Ulica Strzelca
+Ulica Strzelecka
+Ulica Strzelińska
+Ulica Strzeszyńska
+Ulica Strzyżowska
+Ulica Studzienna
+Ulica Sucha
+Ulica Sucholeska
+Ulica Sulechowska
+Ulica Suliszewska
+Ulica Sulmierzycka
+Ulica Sułkowicka
+Ulica Sułowska
+Ulica Suwalska
+Ulica Swantibora
+Ulica Swarożyca
+Ulica Swarzędzka
+Ulica Swoboda
+Ulica Swojska
+Skwer Sybiraków
+Ulica Sycowska
+Ulica Sycylijska
+Ulica Sympatyczna
+Ulica Synów Pułku
+Ulica Sypniewo
+Ulica Syrenia
+Ulica Sytkowska
+Ulica Szadecka
+Ulica Szafirowa
+Ulica Szaflarska
+Ulica Szafranowa
+Ulica Szalupowa
+Ulica Szałwiowa
+Ulica Szamocińska
+Ulica Szamotulska
+Ulica Szantowa
+Ulica Szarotkowa
+Ulica Szarych Szeregów
+Ulica Szczawiowa
+Ulica Szczawnicka
+Ulica Szczecińska
+Ulica Szczepankowo
+Rondo Szczepankowo im. Mycielskich
+Ulica Szczęsna
+Ulica Szczęsnego Dettloffa
+Ulica Szczęśliwa
+Rondo Szczęśliwej Podróży
+Ulica Szczytnicka
+Ulica Szeherezady
+Ulica Szelągowska
+Park Szelągowski
+Ulica Szewska
+Ulica Szklarniowa
+Ulica Szkolna
+Ulica Szkunerowa
+Ulica Szkutnicza
+Ulica Szlachecka
+Ulica Szmaragdowa
+Ulica Szopienicka
+Ulica Szpaków
+Ulica Szparagowa
+Ulica Szpinakowa
+Ulica Szpitalna
+Ulica Szreniawska
+Ulica Szronowa
+Ulica Sztormowa
+Ulica Szubińska
+Ulica Szumiących Traw
+Ulica Szuwarowa
+Ulica Szwadronowa
+Ulica Szwajcarska
+Ulica Szwedzka
+Ulica Szybowcowa
+Ulica Szydłowiecka
+Ulica Szydłowska
+Ulica Szymborska
+Ulica Szyperska
+Ulica Szyszkowa
+Ulica Ścinawska
+Ulica Ślazowa
+Ulica Śląska
+Ulica Ślesińska
+Ulica Ślężańska
+Ulica Śliska
+Ulica Śliwkowa
+Ulica Ślusarska
+Ulica Śmiełowska
+Ulica Śmigi
+Ulica Śmigielska
+Ulica Śniadeckich
+Ulica Śnieżna
+Ulica Śpiewaków
+Ulica Śpiewu Ptaków
+Ulica Średnia
+Ulica Średzka
+Ulica Śremska
+Rynek Śródecki
+Rondo Śródka
+Ulica Śródka
+Ulica Św. Antoniego
+Ulica Św. Barbary
+Ulica Św. Czesława
+Ulica Św. Floriana
+Ulica Św. Jacka
+Ulica Św. Jerzego
+Ulica Św. Kingi
+Ulica Św. Leonarda
+Ulica Św. Marii Magdaleny
+Ulica Św. Michała
+Ulica Św. Rocha
+Ulica Św. Szczepana
+Ulica św. Trójcy
+Ulica Św. Wawrzyńca
+Ulica Św. Wincentego
+Skwer Św. Zygmunta Szczęsnego Felińskiego
+Ulica Światopełka
+Plac Światowida
+Ulica Świątniczki
+Ulica Świdnicka
+Ulica Świebodzińska
+Ulica Świecka
+Ulica Świeradowska
+Rondo Świerczewo
+Ulica Świerkowa
+Ulica Świerzawska
+Ulica Świetlana
+Ulica Świetlikowa
+Ulica Święciańska
+Ulica Świętochny
+Ulica Świętogórska
+Ulica Świętojańska
+Ulica Świętosławska
+Skwer Świętosławy Sygrydy
+Ulica Świętowidzka
+Ulica Święty Marcin
+Ulica Święty Wojciech
+Ulica Świt
+Ulica Taborowa
+Ulica Tadeusza Boya-Żeleńskiego
+Ulica Tadeusza Gajcego
+Park Tadeusza Kasserna
+Ulica Tadeusza Kościuszki
+Ulica Tadeusza Kotarbińskiego
+Park Tadeusza Mazowieckiego
+Ulica Tadeusza Mikke
+Ulica Tadeusza Perkitnego
+Ulica Tadeusza Rejtana
+Ulica Tadeusza Rugego
+Ulica Tadeusza Szeligowskiego
+Ulica Tadeusza Vetulaniego
+Skwer Tajnej Organizacji Nauczycielskiej
+Ulica Tamary Łempickiej
+Ulica Taneczna
+Ulica Tarczowa
+Ulica Tarninowa
+Ulica Tarnobrzeska
+Ulica Tarnowska
+Ulica Tatarakowa
+Ulica Tatrzańska
+Ulica Tczewska
+Ulica Templińska
+Skwer Teodora Łagody
+Ulica Teodora Parnickiego
+Ulica Teodora Tyca
+Ulica Teofila Mateckiego
+Ulica Teokryta
+Skwer Tercetu ABC
+Ulica Terespolska
+Ulica Teresy Remiszewskiej
+Ulica Termalna
+Ulica Ternicka
+Ulica Tęczowa
+Park Thomasa Woodrowa Wilsona
+Ulica Tokarska
+Ulica Tomasza Drobnika
+Ulica Tomasza Zana
+Ulica Tomaszowska
+Ulica Tony Halika
+Ulica Topazowa
+Ulica Topolowa
+Ulica Torfowa
+Ulica Torowa
+Ulica Toruńska
+Ulica Toskańska
+Ulica Towarowa
+Skwer Towarzystwa Miłośników Miasta Poznania
+Park Traszki Ratajskie
+Ulica Treblińska
+Ulica Trębacka
+Ulica Trocka
+Ulica Trójpole
+Ulica Truskawiecka
+Ulica Truskawkowa
+Ulica Trybunalska
+Ulica Trzcianecka
+Ulica Trzebawska
+Ulica Trzebiatowska
+Ulica Trzebińska
+Skwer Trzech Tramwajarek
+Ulica Trzemeszeńska
+Ulica Tucholska
+Ulica Tulipanowa
+Tunel Komandoria
+Tunel Leszka
+Tunel Łomżyński
+Tunel Miłostowo
+Tunel Mogileński
+Tunel Tumski
+Ulica Turkusowa
+Ulica Turniowa
+Ulica Turystyczna
+Ulica Twardogórska
+Ulica Tyczyńska
+Ulica Tylicka
+Ulica Tylne Chwaliszewo
+Ulica Tymiankowa
+Ulica Tyniecka
+Ulica Tyrwacka
+Osiedle Tysiąclecia
+Park Tysiąclecia
+Ulica Tyska
+Ulica Ugory
+Ulica Ułańska
+Ulica Umultowska
+Ulica Unii Europejskiej
+Ulica Unii Lubelskiej
+Ulica Unisława
+Ulica Uniwersytetu Poznańskiego
+Ulica Uprawna
+Ulica Uradzka
+Ulica Urbanowska
+Ulica Urocza
+Ulica Urodzajna
+Ulica Urszulanek
+Ulica Urszuli Ledóchowskiej
+Ulica Urwista
+Ulica Ustronna
+Ulica Ustrońska
+Ulica Ustrzycka
+Ulica Uzdrowiskowa
+Ulica Uznamska
+Skwer Wacława Felczaka
+Ulica Wacława Gieburowskiego
+Skwer Wacława Kopydłowskiego i Leona Stróżczyńskiego
+Ulica Wacława Rzewuskiego
+Ulica Wacława Strażewicza
+Ulica Wadowicka
+Ulica Wagi
+Ulica Wagrowska
+Ulica Walentego Stefańskiego
+Ulica Walerego Wróblewskiego
+Ulica Wałbrzyska
+Ulica Wałecka
+Ulica Wandy
+Rondo Wandy Błeńskiej
+Ulica Wandy Modlibowskiej
+Ulica Wandy Rutkiewicz
+Ulica Waniliowa
+Ulica Warecka
+Ulica Warmińska
+Ulica Warowna
+Ulica Warpińska
+Ulica Warpnowska
+Ulica Warszawska
+Osiedle Warszawskie
+Ulica Warzywna
+Ulica Wawerska
+Ulica Wawrzyńca Engeströma
+Ulica Wągrowiecka
+Ulica Wąska
+Ulica Wąskotorowa
+Ulica Wąwozowa
+Ulica Wczasowa
+Ulica Wdzięczna
+Ulica Wejherowska
+Ulica Wenecjańska
+Ulica Wenedów
+Ulica Wergiliusza
+Ulica Wesoła
+Ulica Węglowa
+Ulica Węgorzewska
+Wiadukt Antoninek im. Orląt Lwowskich
+Wiadukt Gabriela Narutowicza
+Wiadukt Jadwigi Szczawińskiej
+Wiadukt Janiny Czarneckiej
+Wiadukt Kosynierów Górczyńskich
+Wiadukt ks. Władysława Skórnickiego
+Wiadukt Ryszarda Ganowicza
+Ulica Wiankowa
+Ulica Wiatraczna
+Ulica Wiązowa
+Ulica Wichrowa
+Osiedle Wichrowe Wzgórze
+Ulica Widawska
+Ulica Widłakowa
+Ulica Widna
+Ulica Wiece
+Ulica Wieczorynki
+Ulica Wiedeńska
+Ulica Wiejska
+Ulica Wielecka
+Ulica Wielichowska
+Ulica Wielka
+Rondo Wielka Starołęka
+Skwer Wielkiej Orkiestry Świątecznej Pomocy
+Aleja Wielkopolska
+Plac Wielkopolski
+Ulica Wieluńska
+Ulica Wieprawska
+Ulica Wierchowa
+Ulica Wieruszowska
+Ulica Wierzbięcice
+Ulica Wierzbowa
+Ulica Wiesiołkowa
+Ulica Wiesławy
+Ulica Wietrzna
+Ulica Wietrzykowskich
+Ulica Wiewiórcza
+Ulica Wieżowa
+Ulica Więzowska
+Ulica Wiklinowa
+Plac Wiktora Degi
+Ulica Wiktora Gosienieckiego
+Ulica Wiktora Jankowskiego
+Ulica Wiktora Pacajewa
+Ulica Wilanowska
+Ulica Wilcza
+Ulica Wilczak
+Rynek Wildecki
+Ulica Wileńska
+Ulica Wilhelma Grimma
+Ulica Wilkońskich
+Ulica Wilków Morskich
+Ulica Willowa
+Skwer Wincentego I Jana Wierzejewskich
+Ulica Wincentego Jezierskiego
+Ulica Wincentego Kadłubka
+Ulica Wincentego Rapackiego
+Ulica Wincentego Różańskiego
+Ulica Wincentego Styczyńskiego
+Ulica Wincentego Witosa
+Ulica Winiarska
+Osiedle Winiary
+Ulica Winna
+Ulica Winogrady
+Ulica Winogronowa
+Ulica Wiosenna
+Plac Wiosny Ludów
+Ulica Wioślarska
+Ulica Wirska
+Ulica Wisłocka
+Ulica Wiślana
+Ulica Wiślicka
+Ulica Wiśniowa
+Ulica Witkowska
+Ulica Witnicka
+Ulica Witolda Gombrowicza
+Skwer Witolda Jeszkego
+Ulica Witolda Pileckiego
+Ulica Witosława
+Ulica Wituchowska
+Ulica Władymira
+Plac Władysława Andersa
+Skwer Władysława Bartoszewskiego
+Ulica Władysława Bełzy
+Ulica Władysława Biegańskiego
+Ulica Władysława Bortnowskiego
+Park Władysława Czarneckiego
+Osiedle Władysława Jagiełły
+Ulica Władysława Kotwicza
+Ulica Władysława Kozłowskiego
+Osiedle Władysława Łokietka
+Ulica Władysława Nehringa
+Ulica Władysława Orkana
+Ulica Władysława Pniewskiego
+Ulica Władysława Reymonta
+Ulica Władysława Sikorskiego
+Ulica Władysława Syrokomli
+Ulica Władysława Węgorka
+Ulica Władysława Wołkowa
+Ulica Władysława Zamoyskiego
+Ulica Włocławska
+Ulica Włodarska
+Skwer Włodzimierza Dworzaczka
+Ulica Włodzimierza Majakowskiego
+Ulica Włoszakowicka
+Ulica Włościańska
+Ulica Wodna
+Ulica Wodnika
+Ulica Wojciecha Bąka
+Ulica Wojciecha Bogusławskiego
+Skwer Wojciecha Cieślewicza
+Ulica Wojciecha Cybulskiego
+Ulica Wojciecha Korfantego
+Ulica Wojciecha Skowrońskiego
+Ulica Wojciecha Trąmpczyńskiego
+Park Wojciecha Wróża
+Ulica Wojnicka
+Ulica Wojnowicka
+Ulica Wojska Polskiego
+Ulica Wojskowa
+Ulica Wolbromska
+Ulica Wolińska
+Ulica Wolne Tory
+Ulica Wolnica
+Plac Wolności
+Ulica Wolska
+Ulica Wolsztyńska
+Ulica Wołczyńska
+Ulica Wołkowyska
+Ulica Wołowska
+Ulica Wołyńska
+Ulica Wonna
+Ulica Woźna
+Ulica Woźnicka
+Ulica Wójtowska
+Ulica Wrocławska
+Ulica Wronczyńska
+Ulica Wroniecka
+Ulica Wrotyczowa
+Ulica Wrzesińska
+Ulica Wrzosowa
+Rynek Wschodni
+Ulica Wschodnia
+Ulica Wschowska
+Ulica Wspólna
+Ulica Wszechnicy Piastowskiej
+Ulica Wszystkich Świętych
+Ulica Wybieg
+Ulica Wygon
+Ulica Wykopy
+Ulica Wyłom
+Ulica Wypoczynkowa
+Ulica Wyrzyska
+Ulica Wysoka
+Ulica Wyszeborska
+Ulica Wyszomierska
+Ulica Wyzwolenia
+Ulica Wyżyny
+Ulica Wzgórze Kemowe
+Ulica Wzgórze Morenowe
+Ulica Wzgórze św. Wojciecha
+Ulica Wzlotowa
+Ulica Xawerego Dunikowskiego
+Ulica Za Bramką
+Ulica Za Cybiną
+Ulica Za Cytadelą
+Ulica Za Groblą
+Ulica Zaborowska
+Ulica Zabrzańska
+Ulica Zachodnia
+Ulica Zacisze
+Ulica Zagajnikowa
+Ulica Zagonowa
+Ulica Zagórze
+Ulica Zagórzycka
+Ulica Zagrodnicza
+Ulica Zajęcza
+Ulica Zakątek
+Ulica Zaklikowska
+Ulica Zakopiańska
+Ulica Zakręt
+Ulica Załęże
+Ulica Zambrowska
+Ulica Zamiejska
+Ulica Zamknięta
+Ulica Zamkowa
+Ulica Zamojska
+Ulica Zamysłowska
+Ulica Zaniemyska
+Zaułek Haliny Żytkowiak
+Zaułek Krystyny Feldman
+Zaułek Łejerów
+Zaułek Piotra Majchrzaka
+Zaułek Stanisława Zierhoffera
+Zaułek Ślepego Antka
+Ulica Zawady
+Ulica Zawiertowska
+Ulica Zawilcowa
+Ulica Ząbkowicka
+Plac Zbawiciela
+Ulica Zbąszyńska
+Ulica Zbigniewa Burzyńskiego
+Ulica Zbigniewa Herberta
+Ulica Zbigniewa Kiedacza
+Skwer Zbigniewa Wodeckiego
+Ulica Zbożowa
+Ulica Zbyłowita
+Ulica Zbyszka
+Ulica Zdobywców Monte Cassino
+Ulica Zdrojowa
+Ulica Zdunowska
+Ulica Zdziechowska
+Ulica Zdzisława Dworzeckiego
+Ulica Zdzisławy
+Ulica Zemborzycka
+Ulica Zenona Kosidowskiego
+Ulica Zgierska
+Ulica Zgoda
+Ulica Zgorzelecka
+Ulica Ziarnista
+Ulica Zieleńska
+Ulica Zieliniec
+Ulica Zielona
+Skwer Zielone Ogródki im. Zbigniewa Zakrzewskiego
+Ulica Ziemowita
+Ulica Ziemska
+Ulica Ziębicka
+Ulica Zimorodka
+Ulica Zimowa
+Ulica Zjazd
+Ulica Złocieniecka
+Ulica Złocieniowa
+Ulica Złota
+Ulica Złotej Kaczki
+Ulica Złotnicka
+Ulica Złotowska
+Ulica Zmartwychwstańców
+Osiedle Zodiak
+Ulica Zodiakowa
+Skwer Zofii Cieleckiej
+Ulica Zofii Hilczer-Kurnatowskiej
+Ulica Zofii Michałkiewicz
+Ulica Zofii Nałkowskiej
+Ulica Zofii Sokolnickiej
+Ulica Zofii Stryjeńskiej
+Skwer Zofii Ścibor-Rylskiej
+Ulica Zorza
+Ulica Związku Walki Zbrojnej
+Ulica Zwierzyniecka
+Ulica Zwrotnicza
+Osiedle Zwycięstwa
+Ulica Zygmunta Krasińskiego
+Ulica Zygmunta Kubiaka
+Ulica Zygmunta Lisowskiego
+Park Zygmunta Mahlika
+Ulica Zygmunta Noskowskiego
+Osiedle Zygmunta Starego
+Ulica Zygmunta Szweykowskiego
+Ulica Zygmunta Warczygłowy
+Ulica Zygmunta Wojciechowskiego
+Ulica Zygmunta Zaleskiego
+Ulica Zygmunta Żuraszka
+Ulica Źródlana
+Ulica Żabia
+Ulica Żagańska
+Ulica Żaglowa
+Skwer Żandarów
+Ulica Żarnowiecka
+Ulica Żbikowa
+Ulica Żegiestowska
+Ulica Żeglarska
+Rondo Żegrze
+Ulica Żegrze
+Ulica Żelazna
+Ulica Żeńców
+Ulica Żerkowska
+Ulica Żlebowa
+Ulica Żmigrodzka
+Ulica Żmudzka
+Ulica Żnińska
+Ulica Żniwna
+Ulica Żołnierzy Górników
+Ulica Żołnierzy Lenino
+Ulica Żołnierzy Narwiku
+Skwer Żołnierzy Pokojowych Misji Zagranicznych
+Ulica Żołnierzy Wyklętych
+Ulica Żonkilowa
+Ulica Żorska
+Ulica Żukowska
+Ulica Żuławska
+Ulica Żurawia
+Ulica Żurawicka
+Ulica Żurawinowa
+Ulica Żuromińska
+Ulica Żwirowa
+Ulica Żydowska
+Ulica Żytnia
+Ulica Żywiczna
+Ulica Żywiecka
+Ulica Żywocicka
+Ulica Żywokostowa
+Ulica Żyzna

--- a/sources/scripts/teryt.py
+++ b/sources/scripts/teryt.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Skrypt generujący plik TSV z listą ulic, placów, rond na podstawie zrzutu danych z bazy TERYT
+
+https://eteryt.stat.gov.pl/
+"""
+
+import csv
+import logging
+import os
+from xml.etree import ElementTree
+
+logging.basicConfig(level=logging.INFO)
+my_dir = os.path.dirname(os.path.abspath(__file__))
+logging.info(f"My directory is: {my_dir}")
+
+def iterate_teryt_entries() -> iter[dict]:
+    with (open(my_dir + "/../teryt-ulice.xml", "r") as input_file):
+        logging.info(f"Parsing XML from {input_file.name} ...")
+        tree = ElementTree.parse(input_file)
+
+        # <!--Informacje podstawowe:
+        #  Nazwa katalogu: ULIC,
+        #  Zawartość: część,
+        #  Czas utworzenia: 20.06.2026 20:55:15.
+        # -->
+        # <ULIC>
+        #   <row>
+        #     <WOJ>30</WOJ>
+        #     <POW>64</POW>
+        #     <GMI>01</GMI>
+        #     <RODZ_GMI>1</RODZ_GMI>
+        #     <SYM>0969400</SYM>
+        #     <SYM_UL>51915</SYM_UL>
+        #     <CECHA>al.</CECHA>
+        #     <NAZWA_1>Pułku Ułanów Poznańskich</NAZWA_1>
+        #     <NAZWA_2>15</NAZWA_2>
+        #     <STAN_NA>2026-06-19</STAN_NA>
+        #   </row>
+        #
+        #     <CECHA>inne</CECHA>
+        #     <NAZWA_1>zaułek Stanisława Zierhoffera</NAZWA_1>
+        #     <NAZWA_2 />
+        for item in tree.getroot().findall('row'):
+            # 'CECHA': 'ul.', 'NAZWA_1': 'Staszica', 'NAZWA_2': 'Stanisława'
+            # 'CECHA': 'os.', 'NAZWA_1': 'Stefana Batorego', 'NAZWA_2': None
+            item_data: dict[str, str] = {
+                node.tag: node.text or ''
+                for node in item.iter()
+            }
+            logging.debug(f"Found item: {item_data}")
+
+            # https://github.com/macbre/pyrabot/commit/9e24b15396928304ad33a567c778b60dfc9539ba
+            # ul. -> Ulica
+            # os. -> Osiedle
+            # al. -> Aleja
+            # pl. -> Plac
+            cecha = item_data['CECHA']
+
+            if cecha == 'inne':
+                cecha = ''
+            elif cecha == 'ul.':
+                cecha = 'Ulica'
+            elif cecha == 'os.':
+                cecha = 'Osiedle'
+            elif cecha == 'al.':
+                cecha = 'Aleja'
+            elif cecha == 'pl.':
+                cecha = 'Plac'
+
+            yield ' '.join([
+                cecha.capitalize().capitalize(),
+                item_data['NAZWA_2'].title(),
+                item_data['NAZWA_1'],
+            ]).\
+            replace('  ', ' ').\
+            replace('zaułek ', 'Zaułek ').\
+            replace('wiadukt ', 'Wiadukt ').\
+            lstrip()
+
+
+with open(my_dir + "/../../db/teryt.csv", "w") as csv_file:
+    # @see https://docs.python.org/2.7/library/csv.html#csv.writer
+    writer = csv.writer(csv_file)
+
+    for idx, entry in enumerate(iterate_teryt_entries()):
+        logging.info(f"#{idx} | Writing entry: {entry}")
+        writer.writerow([entry])
+
+logging.info("Done")


### PR DESCRIPTION
Zobacz 9e24b15396928304ad33a567c778b60dfc9539ba

```markdown
$ grep Rondo db/teryt.csv | dos2unix | awk '{print "* [["$0"]]"}'
* [[Rondo Alicji Karłowskiej-Kamzowej]]
* [[Rondo Antoniego Wojewody]]
* [[Rondo Bł. Natalii Tułasiewicz]]
* [[Rondo Cichowiczów]]
* [[Rondo Honorowych Dawców Krwi]]
* [[Rondo Jana Nowaka-Jeziorańskiego]]
* [[Rondo Józefa Czapskiego]]
* [[Rondo Józefa Vogla]]
* [[Rondo Kaponiera]]
* [[Rondo Królowej Ryksy Elżbiety]]
* [[Rondo Krzesiny]]
* [[Rondo Krzysztofa Skubiszewskiego]]
* [[Rondo Ks. Antoniego Sroki]]
* [[Rondo Ks. Stanisława Kałka]]
* [[Rondo Ławickich Wydm]]
* [[Rondo Moraczewskich]]
* [[Rondo Obornickie]]
* [[Rondo Obrońców Grodna]]
* [[Rondo Piątkowo]]
* [[Rondo Poznańskich Ogrodników]]
* [[Rondo Rataje]]
* [[Rondo Solidarności]]
* [[Rondo Starołęka]]
* [[Rondo Szczepankowo im. Mycielskich]]
* [[Rondo Szczęśliwej Podróży]]
* [[Rondo Śródka]]
* [[Rondo Świerczewo]]
* [[Rondo Wandy Błeńskiej]]
* [[Rondo Wielka Starołęka]]
* [[Rondo Żegrze]]
```